### PR TITLE
Adaptando para o banco bradesco o valor da transação

### DIFF
--- a/Lib/Transaction.cs
+++ b/Lib/Transaction.cs
@@ -53,7 +53,7 @@ namespace OfxSharpLib
 
          try
          {
-            Amount = Convert.ToDecimal(node.GetValue("//TRNAMT"), CultureInfo.InvariantCulture);
+            Amount = Convert.ToDecimal(node.GetValue("//TRNAMT").Replace(",", "."), CultureInfo.InvariantCulture);
          }
          catch (Exception ex)
          {


### PR DESCRIPTION
Ao importar o arquivo .ofx do bradesco, os valores das transações vem neste formato <TRNAMT>386,80